### PR TITLE
fix(tracing): fix logic for setting `in_app` flag

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -322,7 +322,8 @@ def start_transaction(
 
     :param transaction: The transaction to start. If omitted, we create and
         start a new transaction.
-    :param instrumenter: This parameter is meant for internal use only.
+    :param instrumenter: This parameter is meant for internal use only. It
+        will be removed in the next major version.
     :param custom_sampling_context: The transaction's custom sampling context.
     :param kwargs: Optional keyword arguments to be passed to the Transaction
         constructor. See :py:class:`sentry_sdk.tracing.Transaction` for

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1298,6 +1298,7 @@ class Scope(object):
         event.setdefault("breadcrumbs", {}).setdefault("values", []).extend(
             self._breadcrumbs
         )
+        event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
 
     def _apply_user_to_event(self, event, hint, options):
         # type: (Event, Hint, Optional[Dict[str, Any]]) -> None

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -987,7 +987,8 @@ class Scope(object):
 
         :param transaction: The transaction to start. If omitted, we create and
             start a new transaction.
-        :param instrumenter: This parameter is meant for internal use only.
+        :param instrumenter: This parameter is meant for internal use only. It
+            will be removed in the next major version.
         :param custom_sampling_context: The transaction's custom sampling context.
         :param kwargs: Optional keyword arguments to be passed to the Transaction
             constructor. See :py:class:`sentry_sdk.tracing.Transaction` for
@@ -1054,6 +1055,10 @@ class Scope(object):
         one is not already in progress.
 
         For supported `**kwargs` see :py:class:`sentry_sdk.tracing.Span`.
+
+        The instrumenter parameter is deprecated for user code, and it will
+        be removed in the next major version. Going forward, it should only
+        be used by the SDK itself.
         """
         with new_scope():
             kwargs.setdefault("scope", self)

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -394,6 +394,10 @@ class Span:
         Takes the same arguments as the initializer of :py:class:`Span`. The
         trace id, sampling decision, transaction pointer, and span recorder are
         inherited from the current span/transaction.
+
+        The instrumenter parameter is deprecated for user code, and it will
+        be removed in the next major version. Going forward, it should only
+        be used by the SDK itself.
         """
         configuration_instrumenter = sentry_sdk.Scope.get_client().options[
             "instrumenter"

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -170,6 +170,14 @@ def maybe_create_breadcrumbs_from_span(scope, span):
         )
 
 
+def _get_frame_module_abs_path(frame):
+    # type: (FrameType) -> str
+    try:
+        return frame.f_code.co_filename
+    except Exception:
+        return ""
+
+
 def add_query_source(span):
     # type: (sentry_sdk.tracing.Span) -> None
     """
@@ -200,10 +208,7 @@ def add_query_source(span):
     # Find the correct frame
     frame = sys._getframe()  # type: Union[FrameType, None]
     while frame is not None:
-        try:
-            abs_path = frame.f_code.co_filename
-        except Exception:
-            abs_path = ""
+        abs_path = _get_frame_module_abs_path(frame)
 
         try:
             namespace = frame.f_globals.get("__name__")  # type: Optional[str]
@@ -250,10 +255,7 @@ def add_query_source(span):
         if namespace is not None:
             span.set_data(SPANDATA.CODE_NAMESPACE, namespace)
 
-        try:
-            filepath = frame.f_code.co_filename
-        except Exception:
-            filepath = None
+        filepath = _get_frame_module_abs_path(frame)
         if filepath is not None:
             if namespace is not None:
                 in_app_path = filename_for_module(namespace, filepath)

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -22,6 +22,7 @@ from sentry_sdk.utils import (
     is_sentry_url,
     _is_external_source,
     _module_in_list,
+    _is_in_project_root,
 )
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -218,20 +219,14 @@ def add_query_source(span):
         is_sentry_sdk_frame = namespace is not None and namespace.startswith(
             "sentry_sdk."
         )
+        should_be_included = _module_in_list(namespace, in_app_include)
+        should_be_excluded = _is_external_source(abs_path) or _module_in_list(
+            namespace, in_app_exclude
+        )
 
-        should_be_included = not _is_external_source(abs_path)
-        if namespace is not None:
-            if in_app_exclude and _module_in_list(namespace, in_app_exclude):
-                should_be_included = False
-            if in_app_include and _module_in_list(namespace, in_app_include):
-                # in_app_include takes precedence over in_app_exclude, so doing it
-                # at the end
-                should_be_included = True
-
-        if (
-            abs_path.startswith(project_root)
-            and should_be_included
-            and not is_sentry_sdk_frame
+        if not is_sentry_sdk_frame and (
+            should_be_included
+            or (_is_in_project_root(abs_path, project_root) and not should_be_excluded)
         ):
             break
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1043,7 +1043,7 @@ def event_from_exception(
 
 
 def _module_in_list(name, items):
-    # type: (str, Optional[List[str]]) -> bool
+    # type: (Optional[str], Optional[List[str]]) -> bool
     if name is None:
         return False
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import sys
@@ -389,6 +390,37 @@ def test_breadcrumbs(sentry_init, capture_events):
     capture_exception(ValueError())
     (event,) = events
     assert len(event["breadcrumbs"]["values"]) == 0
+
+
+def test_breadcrumb_ordering(sentry_init, capture_events):
+    sentry_init()
+    events = capture_events()
+
+    timestamps = [
+        datetime.datetime.now() - datetime.timedelta(days=10),
+        datetime.datetime.now() - datetime.timedelta(days=8),
+        datetime.datetime.now() - datetime.timedelta(days=12),
+    ]
+
+    for timestamp in timestamps:
+        add_breadcrumb(
+            message="Authenticated at %s" % timestamp,
+            category="auth",
+            level="info",
+            timestamp=timestamp,
+        )
+
+    capture_exception(ValueError())
+    (event,) = events
+
+    assert len(event["breadcrumbs"]["values"]) == len(timestamps)
+    timestamps_from_event = [
+        datetime.datetime.strptime(
+            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
+        )
+        for x in event["breadcrumbs"]["values"]
+    ]
+    assert timestamps_from_event == sorted(timestamps)
 
 
 def test_attachments(sentry_init, capture_envelopes):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ from sentry_sdk.utils import (
     serialize_frame,
     is_sentry_url,
     _get_installed_modules,
+    _generate_installed_modules,
     ensure_integration_enabled,
     ensure_integration_enabled_async,
 )
@@ -523,7 +524,7 @@ def test_installed_modules():
 
     installed_distributions = {
         _normalize_distribution_name(dist): version
-        for dist, version in _get_installed_modules().items()
+        for dist, version in _generate_installed_modules()
     }
 
     if importlib_available:


### PR DESCRIPTION
Previously, in case packages added in `in_app_include` were installed into a location outside of the project root directory, stack frames from those packages were not marked as `in_app`. Cases include running Python from virtualenv, created outside of the project root directory, or Python packages installed into the system using package managers. This resulted
in inconsistency: traces from the same project would have different `in_app` flags depending on the deployment method.

Steps to reproduce (virtualenv outside of project root):
```
$ docker run --replace --rm --name sentry-postgres -e POSTGRES_USER=sentry -e POSTGRES_PASSWORD=sentry -d -p 5432:5432 postgres
$ distrobox create -i ubuntu:24.04 -n sentry-test-in_app_include-venv
$ distrobox enter sentry-test-in_app_include-venv
$ python3 -m venv /tmp/.venv-test-in_app_include
$ source /tmp/.venv-test-in_app_include/bin/activate
$ pytest tests/integrations/django/test_db_query_data.py::test_query_source_with_in_app_include  # FAIL

```

Steps to reproduce (system packages):
```
$ docker run --replace --rm --name sentry-postgres -e POSTGRES_USER=sentry -e POSTGRES_PASSWORD=sentry -d -p 5432:5432 postgres
$ distrobox create -i ubuntu:24.04 -n sentry-test-in_app_include-os
$ distrobox enter sentry-test-in_app_include-os
$ sudo apt install python3-django python3-pytest python3-pytest-cov python3-pytest-django python3-jsonschema python3-urllib3 python3-certifi python3-werkzeug python3-psycopg2
$ pytest tests/integrations/django/test_db_query_data.py::test_query_source_with_in_app_include  # FAIL
```

In this change, the logic was slightly changed to avoid these discrepancies and conform to the requirements, described in the PR with `in_app` flag introduction: https://github.com/getsentry/sentry-python/pull/1894#issue-1579192436. Note that the `_module_in_list` function returns `False` if `name` is `None`, hence extra check before function call can be omitted to simplify code.

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
